### PR TITLE
Defaulting thumbnail path to document root for better accessibility and support on Windows

### DIFF
--- a/build/util.js
+++ b/build/util.js
@@ -23,7 +23,8 @@ function tmpPath(format) {
 
   var filename = Math.random().toString(36).substring(7);
 
-  return "/tmp/" + filename + "." + format;
+  //defaulting to document root for better accessibility
+  return "./tmp/" + filename + "." + format;
 }
 
 function parseExtension(path) {

--- a/lib/util.js
+++ b/lib/util.js
@@ -21,7 +21,8 @@ function tmpPath (format) {
 	
 	var filename = Math.random().toString(36).substring(7);
 
-	return '/tmp/' + filename + '.' + format;
+	//defaulting to document root for better accessibility
+	return "./tmp/" + filename + "." + format;
 }
 
 function parseExtension (path) {


### PR DESCRIPTION
Was not working on windows due to "/tmp" in path, changed to "./tmp"
